### PR TITLE
Update link to github [Home page]

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ layout: default
             It's <em>unlicensed</em> and <em>easy to use</em>.
         </p>
         <p>
-            <a href="https://github.com/{{ site.theme.github }}" title="{{ site.theme.str_follow_on }} GitHub" class="btn-callout">
+            <a href="https://github.com/zschuessler/DeltaE" title="{{ site.theme.str_follow_on }} GitHub" class="btn-callout">
                 <i class="fa fa-fw fa-github"></i> Get it on Github
             </a>
         </p>


### PR DESCRIPTION
Link error fix. 
Home page: update github link 
https://github.com/ to  http://zschuessler.github.io/DeltaE

Thank you for you great script. 
Best Thierry